### PR TITLE
Update comment about UV texture coordinates

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,8 +72,10 @@ module.exports = {
 
             var axis = this.data.split === 'horizontal' ? 'y' : 'x';
 
-            // !!! NOTE THAT UV texture coordinates, start at the bottom left point of the texture, so y axis coordinates for left eye on horizontal split
-            // are 0.5 - 1.0, and for the right eye are 0.0 - 0.5 (they are swapped from THREE.js 'y' axis logic)
+            // If left eye is set, and the split is horizontal, take the left half of the video texture.
+            // If the split is set to vertical, take the top/upper half of the video texture.
+            // UV texture coordinates start at the bottom left point of the texture, so y axis coordinates for left eye on vertical split
+            // are 0.5 - 1.0, and for the right eye are 0.0 - 0.5
 
             var offset = this.data.eye === 'left' ? (axis === 'y' ? {x: 0, y: 0} : {x: 0, y: 0.5}) : (axis === 'y' ? {x: 0.5, y: 0} : {x: 0, y: 0});
 


### PR DESCRIPTION
I found your comment in the code very confusing. The comment "(they are swapped from THREE.js 'y' axis logic)" doesn't make sense to me, THREE.js y axis is positive up, so that's the same as the texture y coordinate s actually with (0,0) in the bottom left and (1,1) in the top right.
In your comment you talked about "y axis coordinates for left eye on *horizontal* split", I think you meant *vertical* split here, otherwise it doesn't make sense to me that you're talking about y axis values here. That may be the source of your confusion?
I also put back the two lines comments that were before #38 I found those useful.