### PR TITLE
Remove SphereBufferGeometry check

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
           // Note that in A-Frame 0.2.0, sphere entities are THREE.SphereBufferGeometry, while in A-Frame 0.3.0,
           // sphere entities are THREE.BufferGeometry.
 
-          var validGeometries = [THREE.SphereGeometry, THREE.SphereBufferGeometry, THREE.BufferGeometry];
+          var validGeometries = [THREE.SphereGeometry, THREE.BufferGeometry];
           var isValidGeometry = validGeometries.some(function(geometry) {
             return object3D.geometry instanceof geometry;
           });


### PR DESCRIPTION
Remove SphereBufferGeometry check, this is an alias to SphereGeometry in recent threejs version included in aframe 1.4.2.
If you want to keep aframe 1.3.0 compatibility, don't merge it.